### PR TITLE
Add bearer token environment

### DIFF
--- a/lib/Web/Solid/Test/HTTPLists.pm
+++ b/lib/Web/Solid/Test/HTTPLists.pm
@@ -20,6 +20,9 @@ sub http_req_res_list_unauthenticated : Test : Plan(1)  {
 	 for (my $i=0; $i <= $#requests; $i++) {
 		subtest "Request-response #" . ($i+1) => sub {
 		  my $ua = LWP::UserAgent->new;
+		  if ($ENV{SOLID_ENABLE_AUTH}) {
+			 $requests[$i]->header('Authorization' => 'Bearer ' . $ENV{SOLID_BEARER_TOKEN})
+		  }
 		  my $response = $ua->request( $requests[$i] );
 		  my $expected_response = ${$args->{'http-responses'}}[$i];
 		  isa_ok($response, 'HTTP::Response');


### PR DESCRIPTION
Since I'm not sure how the protocol looks for supplying a Pop-token, this is just a very quick writeup that adds two environment variables. Basically, all it does is to add a Bearer token to the `Authorization` header. That bearer token could then be the Pop-token. Would that work?