### PR TITLE
Make use of request-response grouping

### DIFF
--- a/lib/Web/Solid/Test/Basic.pm
+++ b/lib/Web/Solid/Test/Basic.pm
@@ -10,7 +10,7 @@ use Test::Deep;
 use Test::RDF;
 
 our $AUTHORITY = 'cpan:KJETILK';
-our $VERSION   = '0.002';
+our $VERSION   = '0.003_01';
 
 sub http_read_unauthenticated : Test : Plan(4) {
   my ($self, $args) = @_;

--- a/lib/Web/Solid/Test/HTTPLists.pm
+++ b/lib/Web/Solid/Test/HTTPLists.pm
@@ -85,7 +85,7 @@ sub http_req_res_list : Test : Plan(1)  {
 		subtest "Request-response #" . ($counter) =>
 		  \&_subtest_compare_req_res, $request, $response, $pair->{response}; #Callback syntax isn't pretty, admittedly
 		$counter++;
-	 }	 
+	 }
   };
 }
 

--- a/lib/Web/Solid/Test/HTTPLists.pm
+++ b/lib/Web/Solid/Test/HTTPLists.pm
@@ -265,7 +265,8 @@ None
 
 =item 2. That the response code matches the expected one if given.
 
-=item 3. That all headers given in the expected response matches a header in the actual response.
+=item 3. That all headers given in the asserted response matches a
+header in the actual response.
 
 =back
 
@@ -274,7 +275,49 @@ None
 
 Runs a list of two HTTP request response pairs, using a regular
 expression from the first request to set the request URL of the
-second. To be detailed.
+second.
+
+=head3 Parameters
+
+Uses C<test:steps> like above.
+
+Additionally, the first request may have a regular expression that can
+be used to parse data for the next request. To examine the Link
+header, a response message can be formulated like (note, it practice
+it would be more complex):
+
+ :check_acl_location_res a http:ResponseMessage ;
+    httph:link '<(.*?)>;\\s+rel="acl"'^^dqm:regex ;
+    http:status 200 .
+
+The resulting match is placed in an array that will be used to set the
+Request URI of the next request.
+
+
+=head3 Environment
+
+None
+
+=head3 Implements
+
+=over
+
+=item 1. That the regular expression in the first request matches.
+
+=item 2. That responses are L<HTTP::Response> objects.
+
+=item 3. That the response code matches the expected one if given.
+
+=item 4. That headers that are not matched as regular expression but
+given in the asserted response matches a header in the actual
+response.
+
+
+=head3 Assumptions
+
+See the source for details.
+
+
 
 
 =head1 NOTE

--- a/lib/Web/Solid/Test/HTTPLists.pm
+++ b/lib/Web/Solid/Test/HTTPLists.pm
@@ -42,10 +42,9 @@ sub http_req_res_list_regex_reuser : Test : Plan(1)  {
 			 $expected_response->remove_header($expected_header_field); # So that we can test the rest with reusable components
 		  }
 		}
-		
-		#		subtest "Request-response #" . ($i+1) =>
+
 		_subtest_compare_req_res($request, $response, $expected_response);
-		# }
+
 	 };
 
 	 subtest "Second request" => sub {
@@ -265,7 +264,7 @@ None
 =back
 
 
-=head2 C<< http_req_res_list_location >>
+=head2 C<< http_req_res_list_regex_reuser >>
 
 Runs a list of two HTTP request response pairs, using a regular
 expression from the first request to set the request URL of the

--- a/lib/Web/Solid/Test/HTTPLists.pm
+++ b/lib/Web/Solid/Test/HTTPLists.pm
@@ -312,6 +312,8 @@ None
 given in the asserted response matches a header in the actual
 response.
 
+=back
+
 
 =head3 Assumptions
 
@@ -342,8 +344,6 @@ will be changed before an 1.0 release of the system.
 
 Please report any bugs to
 L<https://github.com/kjetilk/p5-web-solid-test-basic/issues>.
-
-=head1 SEE ALSO
 
 =head1 AUTHOR
 

--- a/lib/Web/Solid/Test/HTTPLists.pm
+++ b/lib/Web/Solid/Test/HTTPLists.pm
@@ -11,7 +11,7 @@ use Test::RDF;
 use Data::Dumper;
 
 our $AUTHORITY = 'cpan:KJETILK';
-our $VERSION   = '0.002';
+our $VERSION   = '0.003_01';
 
 my $bearer_predicate = 'http://example.org/httplist/param#bearer'; # TODO: Define proper URI
 

--- a/lib/Web/Solid/Test/HTTPLists.pm
+++ b/lib/Web/Solid/Test/HTTPLists.pm
@@ -205,20 +205,19 @@ tables to L<Test::FITesque>.
 
 =head1 IMPLEMENTED TESTS
 
+Apart from some author tests in this module, examples of actual tests
+can be found in the L<Solid Test Suite|https://github.com/solid/test-suite>.
+
+
 =head2 Test scripts
 
-This package provides C<tests/httplists.t> which runs tests over the
-fixture table in C<tests/data/http-list.ttl>. The test script requires the
-environment variable C<SOLID_REMOTE_BASE> to be set to the base URL
-that any relative URLs in the fixture tables will be resolved
-against. Thus, the fixture tables themselves are independent of the
-host that will run them.
+In general, tests are formulated in RDF fixture tables, which
+parameterizes the test cases. This parameterization is then given to
+the test scripts. It is intended therefore that only a small number of
+fairly general test scripts will be needed to provide an extensive
+test suite.
 
-To run the test script in the clone of this package, invoke it like this:
-
-  SOLID_REMOTE_BASE="https://kjetiltest4.dev.inrupt.net/" prove -l tests/basic.t
-
-
+These are the test scripts implemented in this module:
 
 
 =head2 C<< http_req_res_list >>
@@ -229,13 +228,21 @@ Runs a list of HTTP request response pairs, checking response against the respon
 
 =over
 
-=item * C<test:requests>
+=item * C<test:steps>
+
+A list of request-response pairs, declared using:
+
+=over
+
+=item * C<test:request>
 
 An RDF list of requests that will be executed towards the server in C<SOLID_REMOTE_BASE>.
 
-=item * C<test:responses>
+=item * C<test:response_assertion>
 
 An RDF list of responses that will be used as corresponding expected responses in the tests.
+
+=back
 
 =item * C<http://example.org/httplist/param#bearer>
 
@@ -243,7 +250,6 @@ A bearer token that if present will be used to authenticate the
 requests given by the above list. The object of this predicate can
 either be a literal bearer token, or a URL, in which case, it will be
 dereferenced and the content will be used as the bearer token.
-
 
 =back
 

--- a/lib/Web/Solid/Test/HTTPLists.pm
+++ b/lib/Web/Solid/Test/HTTPLists.pm
@@ -72,21 +72,22 @@ sub http_req_res_list_location : Test : Plan(1)  {
 
 sub http_req_res_list : Test : Plan(1)  {
   my ($self, $args) = @_;
-  my @requests = @{$args->{'-special'}->{'http-requests'}}; # Unpack for readability
+  my @pairs = @{$args->{'-special'}->{'http-pairs'}}; # Unpack for readability
   my $ua = LWP::UserAgent->new;
   subtest $args->{'-special'}->{description} => sub {
-	 plan tests => scalar @requests;
-	 for (my $i=0; $i <= $#requests; $i++) {
-		my $request = $requests[$i];
+	 plan tests => scalar @pairs;
+	 my $counter = 1;
+	 foreach my $pair (@pairs) {
+		my $request = $pair->{request};
 		_check_origin($request);
 		if ($args->{$bearer_predicate}) {
 		  $request->header( 'Authorization' => _create_authorization_field($args->{$bearer_predicate}, $request->uri));
 		}
 		my $response = $ua->request( $request );
-		my $expected_response = ${$args->{'-special'}->{'http-responses'}}[$i];
-		subtest "Request-response #" . ($i+1) =>
-		  \&_subtest_compare_req_res, $request, $response, $expected_response; #Callback syntax isn't pretty, admittedly
-	 }
+		subtest "Request-response #" . ($counter) =>
+		  \&_subtest_compare_req_res, $request, $response, $pair->{response}; #Callback syntax isn't pretty, admittedly
+		$counter++;
+	 }	 
   };
 }
 

--- a/meta/changes.pret
+++ b/meta/changes.pret
@@ -1,5 +1,15 @@
 # This file acts as the project's changelog.
 
+`Web-Solid-Test-Basic 0.003_01 cpan:KJETILK`
+    issued  2019-09-23;
+    label   "Improve the RDF" ;
+    changeset [
+        dcs:versus `Web-Solid-Test-Basic 0.002 cpan:KJETILK`;
+        item [ rdfs:label "Improve documentation."; a dcs:Documentation; ] ;
+	item [ rdfs:label "Restructure HTTP request-response pair parameterization."; a dcs:BackCompat; ]
+    ] .
+
+
 `Web-Solid-Test-Basic 0.002 cpan:KJETILK`
     issued  2019-08-27;
     label   "Authentication" ;

--- a/meta/changes.pret
+++ b/meta/changes.pret
@@ -1,6 +1,6 @@
 # This file acts as the project's changelog.
 
-`Web-Solid-Test-Basic 0.003_01 cpan:KJETILK`
+`Web-Solid-Test-Basic 0.004 cpan:KJETILK`
     issued  2019-09-23;
     label   "Improve the RDF" ;
     changeset [

--- a/meta/makefile.pret
+++ b/meta/makefile.pret
@@ -6,7 +6,7 @@
     :runtime-requirement    [ :on "Test::More 0.96"^^:CpanId ];
     :runtime-requirement    [ :on "Test::Deep"^^:CpanId ];
     :runtime-requirement    [ :on "Test::RDF"^^:CpanId ];
-    :runtime-requirement    [ :on "Test::FITesque::RDF 0.013_01"^^:CpanId ];
+    :runtime-requirement    [ :on "Test::FITesque::RDF 0.014"^^:CpanId ];
     :runtime-requirement    [ :on "FindBin"^^:CpanId ];
     :runtime-requirement    [ :on "LWP::UserAgent::https"^^:CpanId ];
     :runtime-requirement    [ :on "IO::Socket::SSL"^^:CpanId ];

--- a/meta/makefile.pret
+++ b/meta/makefile.pret
@@ -6,7 +6,7 @@
     :runtime-requirement    [ :on "Test::More 0.96"^^:CpanId ];
     :runtime-requirement    [ :on "Test::Deep"^^:CpanId ];
     :runtime-requirement    [ :on "Test::RDF"^^:CpanId ];
-    :runtime-requirement    [ :on "Test::FITesque::RDF 0.012"^^:CpanId ];
+    :runtime-requirement    [ :on "Test::FITesque::RDF 0.013_01"^^:CpanId ];
     :runtime-requirement    [ :on "FindBin"^^:CpanId ];
     :runtime-requirement    [ :on "LWP::UserAgent::https"^^:CpanId ];
     :runtime-requirement    [ :on "IO::Socket::SSL"^^:CpanId ];

--- a/xt/data/http-basic.ttl
+++ b/xt/data/http-basic.ttl
@@ -3,12 +3,13 @@
 @prefix httph:<http://www.w3.org/2007/ont/httph#> .
 @prefix http: <http://www.w3.org/2007/ont/http#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix nfo:   <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#> .
+@prefix nfo:  <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#> .
+@prefix :     <http://example.org/test#> .
 
-<#test-list> a test:FixtureTable ;
+:test_list a test:FixtureTable ;
     test:fixtures (
-        <#public-writeread-unauthn-alt>
-        <#public-cors-origin-set>
+        :public_writeread_unauthn_alt
+        :public_cors_origin_set
     ) .
 
 <http://example.org/httplist#http_req_res_list>
@@ -17,47 +18,59 @@
     nfo:definesFunction "http_req_res_list" .
 
 
-<#public-writeread-unauthn-alt> a test:AutomatedTest ;
+:public_writeread_unauthn_alt a test:AutomatedTest ;
     test:purpose "A simple test for PUT then GET"@en ;
     test:test_script <http://example.org/httplist#http_req_res_list> ;
     test:params [
-        test:requests ( <#public-writeread-unauthn-alt-put-req> <#public-writeread-unauthn-alt-get-req> ) ;
-        test:responses ( <#public-writeread-unauthn-alt-put-res> <#public-writeread-unauthn-alt-get-res> )
+        test:steps (
+            [
+                test:request :public_writeread_unauthn_alt_put_req ;
+                test:response_assertion :public_writeread_unauthn_alt_put_res
+            ]
+            [
+                test:request :public_writeread_unauthn_alt_get_req ;
+                test:response_assertion :public_writeread_unauthn_alt_get_res
+            ]
+        )
     ] .
 
 
-<#public-writeread-unauthn-alt-put-req> a http:RequestMessage ;
+:public_writeread_unauthn_alt_put_req a http:RequestMessage ;
     http:method "PUT" ;
     httph:content_type "text/turtle" ;
     http:content "</public/verypublic/foobar.ttl#dahut> a <http://example.org/Cryptid> ." ;
     http:requestURI </public/verypublic/foobar.ttl> .
 
-<#public-writeread-unauthn-alt-put-res> a http:ResponseMessage ;
+:public_writeread_unauthn_alt_put_res a http:ResponseMessage ;
     http:status 201 .
 
-<#public-writeread-unauthn-alt-get-req> a http:RequestMessage ;
+:public_writeread_unauthn_alt_get_req a http:RequestMessage ;
     http:method "GET" ;
     http:requestURI </public/verypublic/foobar.ttl> .
 
-<#public-writeread-unauthn-alt-get-res> a http:ResponseMessage ;
+:public_writeread_unauthn_alt_get_res a http:ResponseMessage ;
     httph:content_type "text/turtle" .
 
 
-<#public-cors-origin-set> a test:AutomatedTest ;
+:public_cors_origin_set a test:AutomatedTest ;
     test:purpose "Testing CORS header when Origin is supplied by client"@en ;
     rdfs:isDefinedBy <https://www.w3.org/TR/cors/#syntax>, <https://github.com/solid/solid-spec/blob/master/recommendations-server.md#cors---cross-origin-resource-sharing> ;
     test:test_script <http://example.org/httplist#http_req_res_list> ;
     test:params [
-        test:requests ( <#public-cors-origin-set-req> ) ;
-        test:responses ( <#public-cors-origin-set-res> )
+        test:steps (
+            [
+                test:request :public_cors_origin_set_req ;
+                test:response_assertion :public_cors_origin_set_res
+            ]
+        )
     ] .
 
-<#public-cors-origin-set-req> a http:RequestMessage ;
+:public_cors_origin_set_req a http:RequestMessage ;
     http:method "GET" ;
     httph:origin <https://app.example> ;
     http:requestURI </public/verypublic/foobar.ttl> .
 
-<#public-cors-origin-set-res> a http:ResponseMessage ;
+:public_cors_origin_set_res a http:ResponseMessage ;
     http:status 200 ;
     httph:access_control_allow_origin <https://app.example> .
 

--- a/xt/data/http-put-check-acl.ttl
+++ b/xt/data/http-put-check-acl.ttl
@@ -12,17 +12,25 @@
         :check_acl_location
     ) .
 
-<http://example.org/httplist#http_req_res_list_location> a nfo:SoftwareItem ;
+<http://example.org/httplist#http_req_res_list_regex_reuser> a nfo:SoftwareItem ;
     deps:test-requirement "Web::Solid::Test::HTTPLists"^^deps:CpanId ;
-    nfo:definesFunction "http_req_res_list_location" .
+    nfo:definesFunction "http_req_res_list_regex_reuser" .
 
 
 :check_acl_location a test:AutomatedTest ;
     test:purpose "Determine location and write ACL document"@en ;
-    test:test_script <http://example.org/httplist#http_req_res_list_location> ;
+    test:test_script <http://example.org/httplist#http_req_res_list_regex_reuser> ;
     test:params [
-        test:requests ( :check_acl_location_req :put_new_acl_req ) ;
-        test:responses ( :check_acl_location_res :put_new_acl_res )
+        test:steps (
+            [
+                test:request :check_acl_location_req ;
+                test:response_assertion :check_acl_location_res
+            ]
+            [
+                test:request :put_new_acl_req ;
+                test:response_assertion :put_new_acl_res
+            ]
+        )
     ] .
 
 


### PR DESCRIPTION
This adapts to the changes implemented on the framework level in https://github.com/kjetilk/p5-test-fitesque-rdf/pull/3

It can be merged once that has been released, which should happen shortly. This will address on the test script level these issues:

https://github.com/solid/test-suite/issues/47
https://github.com/solid/test-suite/issues/48
https://github.com/solid/test-suite/issues/49
https://github.com/solid/test-suite/issues/50

Some of these also require changes in the test suite, which I will get to ASAP.