### PR TITLE
Rename and reorganize the distro

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,25 @@
 # NAME
 
-Web::Solid::Test::Basic - Basic Solid Tests
+Web::Solid::Test - Solid Test Scripts
+
+# VERSION
+
+Version 0.011\_01
 
 # SYNOPSIS
 
-```perl
-use Test::FITesque::RDF;
-my $suite = Test::FITesque::RDF->new(source => $file, base_uri => $ENV{SOLID_REMOTE_BASE})->suite;
-$suite->run_tests;
-done_testing;
-```
+    use Test::FITesque::RDF;
+    my $suite = Test::FITesque::RDF->new(source => $file, base_uri => $ENV{SOLID_REMOTE_BASE})->suite;
+    $suite->run_tests;
+    done_testing;
 
 See `tests/basic.t` for a full example.
 
 # DESCRIPTION
 
-## Introduction
-
 The basic idea with these tests is to simplify reuse and formulation
 of fixture tables using the Resource Description Framework (RDF). It
-is in a very early stage, but there are running tests in this module.
+is in an early stage, but there are running tests in this module.
 
 This system is built on [Test::FITesque::RDF](https://metacpan.org/pod/Test::FITesque::RDF), which adds RDF fixture
 tables to [Test::FITesque](https://metacpan.org/pod/Test::FITesque).
@@ -40,75 +40,15 @@ independently of the module, and modules can be installed easily so
 that they can be reused. Nevertheless, it is also natural to package
 these together, like it has been done in this package.
 
-Each module like this one will need to document the tests it
-implements, consider the below an example of how this should be done.
+# TEST MODULES
 
-# IMPLEMENTED TESTS
+The tests will live in test modules, currently, this distribution contains
 
-## Test scripts
+- [Web::Solid::Test::Basic](https://metacpan.org/pod/Web::Solid::Test::Basic)
+=item \* [Web::Solid::Test::HTTPLists](https://metacpan.org/pod/Web::Solid::Test::HTTPLists)
 
-This package provides `tests/basic.t` which runs tests over the
-fixture table in `tests/data/basic.ttl`. The test script requires the
-environment variable `SOLID_REMOTE_BASE` to be set to the base URL
-that any relative URLs in the fixture tables will be resolved
-against. Thus, the fixture tables themselves are independent of the
-host that will run them.
-
-To run the test script in the clone of this package, invoke it like this:
-
-```
-SOLID_REMOTE_BASE="https://kjetiltest4.dev.inrupt.net/" prove -l tests/basic.t
-```
-
-## `http_read_unauthenticated`
-
-Some basic tests for HTTP reads.
-
-### Parameters
-
-- `url`
-
-    The URL to request.
-
-### Environment
-
-None
-
-### Implements
-
-- 1. That an HTTP HEAD request to the given URL succeeds.
-- 2. That an HTTP GET request to the given URL succeeds.
-- 3. That the HEAD and GET requests had the same header fields.
-- 4. That the values of the header fields are the same.
-
-## `http_write_with_bearer`
-
-Test for successful HTTP PUT authenticated with a Bearer token
-
-### Parameters
-
-- `url`
-
-    The URL to request.
-
-### Environment
-
-Set `SOLID_BEARER_TOKEN` to the bearer token to be used in the authorization header.
-
-### Implements
-
-- 1. That an HTTP PUT request to the given URL with a short Turtle payload succeeds.
-
-# NOTE
-
-The parameters above are in the RDF formulated as actual full URIs,
-but where the local part is used here and resolved by the
-[Test::FITesque::RDF](https://metacpan.org/pod/Test::FITesque::RDF) framework, see its documentation for details.
-
-# TODO
-
-The namespaces used in the current fixture tables are examples, and
-will be changed before an 1.0 release of the system.
+Within these, there are test scripts in the form of subroutines
+containing subtests. These are then referenced from the fixture tables. 
 
 # BUGS
 
@@ -116,6 +56,8 @@ Please report any bugs to
 [https://github.com/kjetilk/p5-web-solid-test-basic/issues](https://github.com/kjetilk/p5-web-solid-test-basic/issues).
 
 # SEE ALSO
+
+The [Solid Test Suite](https://github.com/solid/test-suite).
 
 # AUTHOR
 
@@ -127,9 +69,7 @@ This software is Copyright (c) 2019 by Inrupt Inc.
 
 This is free software, licensed under:
 
-```
-The MIT (X11) License
-```
+    The MIT (X11) License
 
 # DISCLAIMER OF WARRANTIES
 

--- a/dist.ini
+++ b/dist.ini
@@ -1,3 +1,4 @@
 ;;class='Dist::Inkt::Profile::KJETILK'
-;;name='Web-Solid-Test-Basic'
+;;name='Web-Solid-Test'
+;;lead_module='Web::Solid::Test::Basic'
 

--- a/lib/Web/Solid/Test.pod
+++ b/lib/Web/Solid/Test.pod
@@ -54,6 +54,7 @@ The tests will live in test modules, currently, this distribution contains
 =over
 
 =item * L<Web::Solid::Test::Basic>
+
 =item * L<Web::Solid::Test::HTTPLists>
 
 =back
@@ -73,7 +74,7 @@ L<https://github.com/kjetilk/p5-web-solid-test-basic/issues>.
 
 =head1 SEE ALSO
 
-The L<Solid Test Suite|https://github.com/solid/test-suite>.
+This was primarily developed for the L<Solid Test Suite|https://github.com/solid/test-suite>.
 
 =head1 AUTHOR
 

--- a/lib/Web/Solid/Test.pod
+++ b/lib/Web/Solid/Test.pod
@@ -7,6 +7,12 @@
 
 Web::Solid::Test - Solid Test Scripts
 
+
+=head1 VERSION
+
+Version 0.011_01
+
+
 =head1 SYNOPSIS
 
   use Test::FITesque::RDF;

--- a/lib/Web/Solid/Test.pod
+++ b/lib/Web/Solid/Test.pod
@@ -1,0 +1,90 @@
+
+=pod
+
+=encoding utf-8
+
+=head1 NAME
+
+Web::Solid::Test - Solid Test Scripts
+
+=head1 SYNOPSIS
+
+  use Test::FITesque::RDF;
+  my $suite = Test::FITesque::RDF->new(source => $file, base_uri => $ENV{SOLID_REMOTE_BASE})->suite;
+  $suite->run_tests;
+  done_testing;
+
+See C<tests/basic.t> for a full example.
+
+=head1 DESCRIPTION
+
+The basic idea with these tests is to simplify reuse and formulation
+of fixture tables using the Resource Description Framework (RDF). It
+is in an early stage, but there are running tests in this module.
+
+This system is built on L<Test::FITesque::RDF>, which adds RDF fixture
+tables to L<Test::FITesque>.
+
+Then, the idea is that modules such as this will provide a reusable
+implementation of certain tests, and that they can be adapted to
+concrete test scenarios by either passing parameters from the RDF
+tables (for both input variables and expected outcomes), or using
+environment variables.
+
+To run the actual tests, test scripts will be made, but they should be
+terse as their only mission is to initialize the test framework, see
+the synopsis for an example of such a script. The script can then be
+invoked by e.g. CI systems or used in development.
+
+The RDF fixture tables and the small wrapper scripts can exist
+independently of the module, and modules can be installed easily so
+that they can be reused. Nevertheless, it is also natural to package
+these together, like it has been done in this package.
+
+=head1 TEST MODULES
+
+The tests will live in test modules, currently, this distribution contains
+
+=over
+
+=item * L<Web::Solid::Test::Basic>
+=item * L<Web::Solid::Test::HTTPLists>
+
+=back
+
+Within these, there are test scripts in the form of subroutines
+containing subtests. These are then referenced from the fixture tables. 
+
+
+
+
+
+
+=head1 BUGS
+
+Please report any bugs to
+L<https://github.com/kjetilk/p5-web-solid-test-basic/issues>.
+
+=head1 SEE ALSO
+
+The L<Solid Test Suite|https://github.com/solid/test-suite>.
+
+=head1 AUTHOR
+
+Kjetil Kjernsmo E<lt>kjetilk@cpan.orgE<gt>.
+
+=head1 COPYRIGHT AND LICENCE
+
+This software is Copyright (c) 2019 by Inrupt Inc.
+
+This is free software, licensed under:
+
+  The MIT (X11) License
+
+
+=head1 DISCLAIMER OF WARRANTIES
+
+THIS PACKAGE IS PROVIDED "AS IS" AND WITHOUT ANY EXPRESS OR IMPLIED
+WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF
+MERCHANTIBILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+

--- a/lib/Web/Solid/Test/Basic.pm
+++ b/lib/Web/Solid/Test/Basic.pm
@@ -136,35 +136,8 @@ See C<tests/basic.t> for a full example.
 
 =head1 DESCRIPTION
 
-=head2 Introduction
-
-The basic idea with these tests is to simplify reuse and formulation
-of fixture tables using the Resource Description Framework (RDF). It
-is in a very early stage, but there are running tests in this module.
-
-This system is built on L<Test::FITesque::RDF>, which adds RDF fixture
-tables to L<Test::FITesque>.
-
-Then, the idea is that modules such as this will provide a reusable
-implementation of certain tests, and that they can be adapted to
-concrete test scenarios by either passing parameters from the RDF
-tables (for both input variables and expected outcomes), or using
-environment variables.
-
-To run the actual tests, test scripts will be made, but they should be
-terse as their only mission is to initialize the test framework, see
-the synopsis for an example of such a script. The script can then be
-invoked by e.g. CI systems or used in development.
-
-The RDF fixture tables and the small wrapper scripts can exist
-independently of the module, and modules can be installed easily so
-that they can be reused. Nevertheless, it is also natural to package
-these together, like it has been done in this package.
-
-Each module like this one will need to document the tests it
-implements, consider the below an example of how this should be done.
-
-
+See L<Web::Solid::Test> for an introduction to the idea behind these
+test modules.
 
 =head1 IMPLEMENTED TESTS
 

--- a/lib/Web/Solid/Test/Basic.pm
+++ b/lib/Web/Solid/Test/Basic.pm
@@ -10,7 +10,7 @@ use Test::Deep;
 use Test::RDF;
 
 our $AUTHORITY = 'cpan:KJETILK';
-our $VERSION   = '0.010';
+our $VERSION   = '0.011_01';
 
 sub http_read_unauthenticated : Test : Plan(4) {
   my ($self, $args) = @_;

--- a/lib/Web/Solid/Test/HTTPLists.pm
+++ b/lib/Web/Solid/Test/HTTPLists.pm
@@ -207,8 +207,8 @@ A script C<tests/httplists.t> can be used to launch some of these tests.
 The basic idea with these tests is to simplify reuse and formulation
 of fixture tables using the Resource Description Framework (RDF), in
 this case using HTTP vocabularies to formulate lists of requests and
-responses. It is in a very early stage, but there are running tests in
-this module. See L<Web::Solid::Test::Basic> for more on the
+responses. It is in an early stage, but there are running tests in
+this module. See L<Web::Solid::Test> for more on the
 philosophy.
 
 This system is built on L<Test::FITesque::RDF>, which adds RDF fixture

--- a/lib/Web/Solid/Test/HTTPLists.pm
+++ b/lib/Web/Solid/Test/HTTPLists.pm
@@ -11,7 +11,7 @@ use Test::RDF;
 use Data::Dumper;
 
 our $AUTHORITY = 'cpan:KJETILK';
-our $VERSION   = '0.010';
+our $VERSION   = '0.011_01';
 
 my $bearer_predicate = 'http://example.org/httplist/param#bearer'; # TODO: Define proper URI
 

--- a/meta/changes.pret
+++ b/meta/changes.pret
@@ -1,5 +1,14 @@
 # This file acts as the project's changelog.
 
+`Web-Solid-Test 0.011_01 cpan:KJETILK`
+    issued  2020-03-12;
+    label   "Rename the distribution" ;
+    changeset [
+        dcs:versus `Web-Solid-Test-Basic 0.010 cpan:KJETILK`;
+	item [ rdfs:label "Add a POD for the main documentation"; a dcs:Addition; ] ;
+	item [ rdfs:label "Rename the distribution."; a dcs:Change; ]
+    ] .
+
 `Web-Solid-Test-Basic 0.010 cpan:KJETILK`
     issued  2020-02-24;
     label   "Improve support when using regular expressions" ;

--- a/meta/doap.pret
+++ b/meta/doap.pret
@@ -4,11 +4,11 @@
 @prefix dc:   <http://purl.org/dc/terms/> .
 @prefix prov: <http://www.w3.org/ns/prov#>.
 
-`Web-Solid-Test-Basic`
+`Web-Solid-Test`
    :programming-language "Perl" ;
-   :shortdesc            "Basic Solid Tests";
-   :homepage             <https://metacpan.org/release/Web-Solid-Test-Basic>;
-   :download-page        <https://metacpan.org/release/Web-Solid-Test-Basic>;
+   :shortdesc            "Solid Test Scriptss";
+   :homepage             <https://metacpan.org/release/Web-Solid-Test>;
+   :download-page        <https://metacpan.org/release/Web-Solid-Test>;
    :bug-database         <https://github.com/kjetilk/p5-web-solid-test-basic/issues>;
    :repository           [ a :GitRepository;
                            :browse <https://github.com/kjetilk/p5-web-solid-test-basic>;

--- a/meta/doap.pret
+++ b/meta/doap.pret
@@ -6,7 +6,7 @@
 
 `Web-Solid-Test`
    :programming-language "Perl" ;
-   :shortdesc            "Solid Test Scriptss";
+   :shortdesc            "Solid Test Scripts";
    :homepage             <https://metacpan.org/release/Web-Solid-Test>;
    :download-page        <https://metacpan.org/release/Web-Solid-Test>;
    :bug-database         <https://github.com/kjetilk/p5-web-solid-test-basic/issues>;

--- a/meta/makefile.pret
+++ b/meta/makefile.pret
@@ -2,7 +2,7 @@
 
 @prefix : <http://ontologi.es/doap-deps#>.
 
-`Web-Solid-Test-Basic`
+`Web-Solid-Test`
     :test-requirement       [ :on "Net::EmptyPort"^^:CpanId ];
     :test-requirement       [ :on "Types::Standard"^^:CpanId ];		
     :test-requirement       [ :on "HTTP::Server::Simple::PSGI"^^:CpanId ];


### PR DESCRIPTION
This adds a plain, old documentation file at the top, and therefore serves to rename the distribution. 

I'm not entirely sure CPAN would react to this, the pre-release seems fine though. 

This would resolve #12 .